### PR TITLE
Fix/refactor/#83

### DIFF
--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -3,7 +3,10 @@ import { create } from "superstruct";
 import { STATIC_PATH } from "../lib/constance";
 import { QueryStruct } from "../validators/CompanyStructs";
 import { SearchByContractDraft } from "../typings/pagination";
-import { ContractDraftItemDto } from "../dto/contractDocument.dto";
+import {
+  ContractDraftItemDto,
+  ContractDocumentListDto,
+} from "../dto/contractDocument.dto";
 import { SaveFileInfo } from "../typings/contrarctDocument";
 import path from "path";
 import BadRequestError from "../errors/BadRequestError";
@@ -20,7 +23,7 @@ export const getAllContractDocumentListHandler = async (
     if (!user || !user.company || !user.company.id) {
       res.status(401).json({ message: "로그인이 필요합니다." });
     }
-    const companyId = user.company.companyCode;
+    const companyId = user.company.id;
     const {
       page = 1,
       pageSize = 10,
@@ -29,14 +32,17 @@ export const getAllContractDocumentListHandler = async (
       searchBy,
     } = create(req.query, QueryStruct);
 
-    const result = await contractDocumentService.contractDocumentList({
+    const requestDto: ContractDocumentListDto = {
       page: Number(page),
       pageSize: Number(pageSize),
       searchBy: searchBy as SearchByContractDraft,
       keyword: keyword as string | undefined,
       orderBy: orderBy as "recent" | "oldest",
-      companyId: user.company.id,
-    });
+      companyId,
+    };
+    const result = await contractDocumentService.contractDocumentList(
+      requestDto
+    );
     res.status(200).json(result);
   } catch (error) {
     next(error);

--- a/src/controllers/contractDocumentController.ts
+++ b/src/controllers/contractDocumentController.ts
@@ -16,6 +16,11 @@ export const getAllContractDocumentListHandler = async (
   next: NextFunction
 ): Promise<void> => {
   try {
+    const user = req.user;
+    if (!user || !user.company || !user.company.id) {
+      res.status(401).json({ message: "로그인이 필요합니다." });
+    }
+    const companyId = user.company.companyCode;
     const {
       page = 1,
       pageSize = 10,
@@ -30,6 +35,7 @@ export const getAllContractDocumentListHandler = async (
       searchBy: searchBy as SearchByContractDraft,
       keyword: keyword as string | undefined,
       orderBy: orderBy as "recent" | "oldest",
+      companyId: user.company.id,
     });
     res.status(200).json(result);
   } catch (error) {
@@ -43,8 +49,12 @@ export const getContractDraftListHandler = async (
   next: NextFunction
 ): Promise<void> => {
   try {
+    const user = req.user;
+    if (!user || !user.company) {
+      res.status(401).json({ message: "로그인이 필요합니다." });
+    }
     const result: ContractDraftItemDto[] =
-      await contractDocumentService.contractDraftList();
+      await contractDocumentService.contractDraftList(user.company.id);
     res.status(200).json(result);
   } catch (error) {
     next(error);

--- a/src/dto/contractDocument.dto.ts
+++ b/src/dto/contractDocument.dto.ts
@@ -1,3 +1,5 @@
+import { SearchByContract, SearchByContractDraft } from "../typings/pagination";
+
 export interface ContractDraftItemDto {
   id: number;
   data: string;
@@ -18,6 +20,15 @@ export interface ContractDocumentItemDto {
     id: number;
     fileName: string;
   }[];
+}
+
+export interface ContractDocumentListDto {
+  page: number;
+  pageSize: number;
+  keyword?: string;
+  orderBy: "recent" | "oldest";
+  searchBy: SearchByContractDraft;
+  companyId: number;
 }
 
 export interface PageContractDocumentItemDto {

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -38,6 +38,7 @@ const authMiddleware = async (
       email: user.email,
       isAdmin: user.isAdmin,
       company: {
+        id: user.company.id,
         companyCode: user.company?.companyCode || "",
       },
     };

--- a/src/repositories/contractDocumentRepository.ts
+++ b/src/repositories/contractDocumentRepository.ts
@@ -10,8 +10,13 @@ const getAllcontractDocumentList = async ({
   pageSize,
   keyword,
   orderBy,
-}: PaginationParams<SearchByContractDraft>) => {
-  const where = {};
+  companyId,
+}: PaginationParams<SearchByContractDraft> & { companyId: number }) => {
+  const where = {
+    user: {
+      companyId: companyId,
+    },
+  };
   const contracts = await prisma.contract.findMany({
     where,
     skip: (page - 1) * pageSize,
@@ -31,8 +36,13 @@ const getAllcontractDocumentList = async ({
 };
 
 // 계약서 추가 화면에서 계약목록조회
-const getContractList = async () => {
+const getContractList = async (companyId: number) => {
   const contracts = await prisma.contract.findMany({
+    where: {
+      user: {
+        companyId: companyId,
+      },
+    },
     include: {
       customer: true,
       car: { include: { model: true } },

--- a/src/services/contractDocumentService.ts
+++ b/src/services/contractDocumentService.ts
@@ -10,9 +10,9 @@ import { SaveFileInfo } from "../typings/contrarctDocument";
 import BadRequestError from "../errors/BadRequestError";
 
 const contractDocumentList = async (
-  params: PaginationParams<SearchByContractDraft>
+  params: PaginationParams<SearchByContractDraft> & { companyId: number }
 ): Promise<PageContractDocumentItemDto> => {
-  const { page, pageSize, keyword } = params;
+  const { page, pageSize, keyword, companyId } = params;
   const { contracts } = await contractDocumentRepo.getAllcontractDocumentList(
     params
   );
@@ -56,8 +56,10 @@ const contractDocumentList = async (
   };
 };
 
-const contractDraftList = async (): Promise<ContractDraftItemDto[]> => {
-  const contracts = await contractDocumentRepo.getContractList();
+const contractDraftList = async (
+  companyId: number
+): Promise<ContractDraftItemDto[]> => {
+  const contracts = await contractDocumentRepo.getContractList(companyId);
 
   return contracts.map((c) => ({
     id: c.id,

--- a/src/swagger/companies.swagger.yaml
+++ b/src/swagger/companies.swagger.yaml
@@ -1,4 +1,4 @@
-/companies:
+companies:
   post:
     summary: 회사 등록
     tags:
@@ -106,7 +106,7 @@
       "401":
         description: 인증 실패 - 관리자 권한 필요
 
-/companies/users:
+users:
   get:
     summary: 회사별 유저 조회
     tags:
@@ -182,6 +182,7 @@
       "401":
         description: 인증 실패 - 권한 필요
 
+companyId:
   patch:
     summary: 회사 정보 수정
     tags:
@@ -189,7 +190,7 @@
     security:
       - bearerAuth: []
     parameters:
-      - name: comapanyId
+      - name: companyId
         in: path
         description: 회사 ID
         required: true
@@ -212,23 +213,6 @@
     responses:
       "200":
         description: 회사 정보 수정 성공
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: integer
-                  example: 1
-                companyName:
-                  type: string
-                  example: "ABC 자동차"
-                companyCode:
-                  type: string
-                  example: "ABC001"
-                userCount:
-                  type: integer
-                  example: 3
       "400":
         description: 잘못된 요청입니다.
       "401":
@@ -236,7 +220,6 @@
       "404":
         description: 존재하지 않는 회사입니다.
 
-/companies/{companyId}:
   delete:
     summary: 회사 삭제
     tags:

--- a/src/swagger/contractDocument.swagger.yaml
+++ b/src/swagger/contractDocument.swagger.yaml
@@ -1,4 +1,4 @@
-/contractDocuments:
+contractDocuments:
   get:
     summary: 계약서 업로드 시 계약 목록조회
     tags:
@@ -88,3 +88,31 @@
       description: 잘못된 요청입니다.
     "401":
       description: 로그인이 필요합니다.
+
+draft:
+  get:
+    summary: 계약서 추가 시 계약 목록 조회
+    tags:
+      - ContractDocuments
+    security:
+      - bearerAuth: []
+    responses:
+      "200":
+        description: 데이터 조회 성공
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  id:
+                    type: integer
+                    example: 1
+                  data:
+                    type: string
+                    example: "k9 - 홍길동 고객님"
+      "400":
+        description: 잘못된 요청입니다.
+      "401":
+        description: 로그인이 필요합니다.

--- a/src/swagger/contractDocument.swagger.yaml
+++ b/src/swagger/contractDocument.swagger.yaml
@@ -116,3 +116,79 @@ draft:
         description: 잘못된 요청입니다.
       "401":
         description: 로그인이 필요합니다.
+
+upload:
+  post:
+    summary: 계약서 파일 업로드
+    tags:
+      - ContractDocuments
+    security:
+      - bearerAuth: []
+    requestBody:
+      required: true
+      content:
+        multipart/form-data:
+          schema:
+            type: object
+            properties:
+              contractDocument:
+                type: string
+                format: binary
+                description: 업로드용 계약서 파일
+    responses:
+      "200":
+        description: 업로드성공
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                contractDocumentId:
+                  type: integer
+                  example: 1
+      "401":
+        description: 로그인이 필요합니다.
+        content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              message:
+                type: string
+                example: 로그인이 필요합니다
+
+contractDocumentId/download:
+  get:
+    summary: 계약서 다운로드
+    tags:
+      - ContractDocuments
+    security:
+      - bearerAuth: []
+    parameters:
+      - name: contractDocumentId
+        in: path
+        required: true
+        description: 계약서 ID
+        schema:
+          type: integer
+    responses:
+      "200":
+        description: 계약서 다운로드 성공
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: 계약서 다운로드 성공
+      "401":
+        description: 로그인이 필요합니다.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                message:
+                  type: string
+                  example: 로그인이 필요합니다

--- a/src/swagger/openapi.yaml
+++ b/src/swagger/openapi.yaml
@@ -14,8 +14,13 @@ paths:
     $ref: "./companies.swagger.yaml#/users"
   /companies/{companyId}:
     $ref: "./companies.swagger.yaml#/companyId"
+
   # 계약서
   /contractDocuments:
     $ref: "./contractDocument.swagger.yaml#/contractDocuments"
   /contractDocuments/draft:
     $ref: "./contractDocument.swagger.yaml#/draft"
+  /contractDocuments/upload:
+    $ref: "./contractDocument.swagger.yaml#/upload"
+  /contractDocuments/{contractDocumentId}/download:
+    $ref: "./contractDocument.swagger.yaml#/contractDocumentId/download"

--- a/src/swagger/openapi.yaml
+++ b/src/swagger/openapi.yaml
@@ -7,4 +7,15 @@ servers:
   - url: http://localhost:3000
 
 paths:
-  $ref: "./companies.swagger.yaml"
+  # 회사
+  /companies:
+    $ref: "./companies.swagger.yaml#/companies"
+  /companies/users:
+    $ref: "./companies.swagger.yaml#/users"
+  /companies/{companyId}:
+    $ref: "./companies.swagger.yaml#/companyId"
+  # 계약서
+  /contractDocuments:
+    $ref: "./contractDocument.swagger.yaml#/contractDocuments"
+  /contractDocuments/draft:
+    $ref: "./contractDocument.swagger.yaml#/draft"

--- a/src/typings/express.d.ts
+++ b/src/typings/express.d.ts
@@ -8,6 +8,7 @@ export interface AuthenticatedUser {
   email: string;
   isAdmin: boolean;
   company: {
+    id: number;
     companyCode: string;
   };
 }
@@ -23,4 +24,3 @@ declare global {
     }
   }
 }
-


### PR DESCRIPTION
contractDocument 라우터에서 목록조회 하는 부분 유저 정보 추가해서 회사별 계약목록 볼수있게 수정

express.d.ts에서 company에 id추가 (스키마 구조 -> user 와 contractdocument 가 id로만 참조하고있어서 필요함)

authmiddleware.ts user정보에 company.id추가
