### PR TITLE
Refactor/car api/#130

### DIFF
--- a/src/controllers/carController.ts
+++ b/src/controllers/carController.ts
@@ -29,17 +29,13 @@ export const createCar = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
-  try {
-    const carRequest: CreateCarDTO = create(req.body, CarStruct);
+): Promise<void> => {
+  const carRequest: CreateCarDTO = create(req.body, CarStruct);
 
-    const newCar = await carService.createCar(carRequest, req.user.companyId);
-    const response: CreateCarResponseDTO = mapToCarResponse(newCar);
+  const newCar = await carService.createCar(carRequest, req.user.companyId);
+  const response: CreateCarResponseDTO = mapToCarResponse(newCar);
 
-    res.status(201).json(response);
-  } catch (err) {
-    next(err);
-  }
+  res.status(201).json(response);
 };
 
 // 차량 목록 조회
@@ -47,10 +43,10 @@ export const getCarList = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
+): Promise<void> => {
   const {
     page = 1,
-    pageSize = 3,
+    pageSize = 10,
     status,
     orderBy,
     searchBy,
@@ -81,23 +77,19 @@ export const getCarById = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
-  try {
-    const carId: CarByIdDTO = { id: Number(req.params.id) };
+): Promise<void> => {
+  const carId: CarByIdDTO = { id: Number(req.params.id) };
 
-    const car: GetCarByIdResponseDTO = await carService.getCarById(carId.id);
+  const car: GetCarByIdResponseDTO = await carService.getCarById(carId.id);
 
-    res.status(200).json(car);
-  } catch (error) {
-    next(error);
-  }
+  res.status(200).json(car);
 };
 
 export const getAllCarModels = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
+): Promise<void> => {
   const manufacturersWithModels: GetAllCarModelsResponseDTO =
     await carService.getAllCarModels();
 
@@ -109,20 +101,16 @@ export const updateCar = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
-  try {
-    const carRequest: UpdateCarDTO = create(req.body, UpdateCarStruct);
+): Promise<void> => {
+  const carRequest: UpdateCarDTO = create(req.body, UpdateCarStruct);
 
-    const carId: number = Number(req.params.id);
+  const carId: number = Number(req.params.id);
 
-    const updatedCar = await carService.updateCar(carId, carRequest);
+  const updatedCar = await carService.updateCar(carId, carRequest);
 
-    const response: UpdateCarResponseDTO = mapToCarResponse(updatedCar);
+  const response: UpdateCarResponseDTO = mapToCarResponse(updatedCar);
 
-    res.status(200).json(response);
-  } catch (err) {
-    next(err);
-  }
+  res.status(200).json(response);
 };
 
 //차량 삭제
@@ -130,14 +118,10 @@ export const deleteCar = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
-  try {
-    const carId: CarByIdDTO = { id: Number(req.params.id) };
-    await carService.deleteCar(carId.id);
-    res.status(204).send();
-  } catch (err) {
-    next(err);
-  }
+): Promise<void> => {
+  const carId: CarByIdDTO = { id: Number(req.params.id) };
+  await carService.deleteCar(carId.id);
+  res.status(204).send();
 };
 
 // CSV 업로드 및 차량 등록
@@ -145,7 +129,7 @@ export const uploadCarsFromCSV = async (
   req: Request,
   res: Response,
   next: NextFunction
-) => {
+): Promise<void> => {
   if (!req.file) {
     res.status(400).json({ message: "CSV 파일이 없습니다." });
     return;
@@ -181,8 +165,8 @@ export const uploadCarsFromCSV = async (
         const saved: UploadCarResponseDTO =
           await carService.bulkCreateCarsService(cars, companyId);
         res.status(201).json(saved);
-      } catch (err) {
-        next(err);
+      } catch (error) {
+        next(error);
       }
     });
 };

--- a/src/dto/carsDTO.ts
+++ b/src/dto/carsDTO.ts
@@ -8,7 +8,7 @@ export type CreateCarResponseDTO = CarResponse;
 //차량 목록 조회
 export type CarListResponseDTO = {
   currentPage: number;
-  totalPage: number;
+  totalPages: number;
   totalItemCount: number;
   data: CarResponse[];
 };

--- a/src/repositories/carsRepository.ts
+++ b/src/repositories/carsRepository.ts
@@ -94,7 +94,7 @@ async function getCarList({
 
   return {
     currentPage: page,
-    totalPage: Math.ceil(totalCount / pageSize),
+    totalPages: Math.ceil(totalCount / pageSize),
     totalItemCount: totalCount,
     data: cars,
   };
@@ -154,10 +154,27 @@ async function deleteCar(id: number) {
 }
 
 // 대량 차량 등록
-async function bulkCreateCars(carList: CarData[]) {
-  return prisma.car.createMany({
+async function bulkCreateCars(
+  tx: Prisma.TransactionClient,
+  carList: CarData[]
+) {
+  return tx.car.createMany({
     data: carList,
     skipDuplicates: true,
+  });
+}
+
+async function bulkFindModel(
+  tx: Prisma.TransactionClient,
+  options: { name: string; manufacturerName: string }
+) {
+  return tx.models.findFirst({
+    where: {
+      name: options.name,
+      manufacturer: {
+        name: options.manufacturerName,
+      },
+    },
   });
 }
 
@@ -171,4 +188,5 @@ export default {
   deleteCar,
   bulkCreateCars,
   findModel,
+  bulkFindModel,
 };

--- a/src/services/carsService.ts
+++ b/src/services/carsService.ts
@@ -6,6 +6,7 @@ import { CarList, UpdateCar, CarResponse, CarData } from "../typings/car";
 import { mapToCarResponse } from "../utils/CarResponse";
 import { CarStatus } from "@prisma/client";
 import { CarRequest } from "../typings/car";
+import prisma from "../lib/prisma";
 
 // 차량 등록
 export const createCar = async (
@@ -54,7 +55,7 @@ async function getCarList(params: CarPaginationParams): Promise<CarList> {
 
   return {
     currentPage: result.currentPage,
-    totalPage: result.totalPage,
+    totalPages: result.totalPages,
     totalItemCount: result.totalItemCount,
     data: mappedData,
   };
@@ -136,39 +137,68 @@ async function bulkCreateCarsService(carList: CarRequest[], companyId: number) {
     throw new Error("등록할 차량 정보가 없습니다.");
   }
 
-  const processedCars: CarData[] = [];
+  for (const [i, car] of carList.entries()) {
+    if (
+      !car.carNumber?.trim() ||
+      !car.manufacturer?.trim() ||
+      !car.model?.trim() ||
+      !car.manufacturingYear ||
+      !car.mileage ||
+      !car.price
+    ) {
+      const missingFields = [];
+      if (!car.carNumber?.trim()) missingFields.push("carNumber");
+      if (!car.manufacturer?.trim()) missingFields.push("manufacturer");
+      if (!car.model?.trim()) missingFields.push("model");
+      if (!car.manufacturingYear) missingFields.push("manufacturingYear");
+      if (!car.mileage) missingFields.push("mileage");
+      if (!car.price) missingFields.push("price");
 
-  for (const car of carList) {
-    const model = await carRepository.findModel({
-      name: car.model,
-      manufacturerName: car.manufacturer,
-    });
-
-    if (!model) {
       throw new BadRequestError(
-        `모델 정보 없음: ${car.manufacturer} ${car.model} ${car.manufacturingYear}`
+        `CSV ${
+          i + 1
+        }번째 항목의 필수 값이 누락되었습니다. 누락된 필드: ${missingFields.join(
+          ", "
+        )}`
       );
     }
-
-    processedCars.push({
-      carNumber: car.carNumber,
-      modelId: model.id,
-      companyId,
-      year: car.manufacturingYear,
-      mileage: car.mileage,
-      price: car.price,
-      accidentCount: car.accidentCount,
-      explanation: car.explanation || null,
-      accidentDetails: car.accidentDetails || null,
-      status: "possession",
-    });
   }
 
-  await carRepository.bulkCreateCars(processedCars);
+  return await prisma.$transaction(async (tx) => {
+    const processedCars: CarData[] = [];
 
-  return {
-    count: processedCars.length,
-  };
+    for (const car of carList) {
+      const model = await carRepository.bulkFindModel(tx, {
+        name: car.model,
+        manufacturerName: car.manufacturer,
+      });
+
+      if (!model) {
+        throw new BadRequestError(
+          `모델 정보 없음: ${car.manufacturer} ${car.model} ${car.manufacturingYear}`
+        );
+      }
+
+      processedCars.push({
+        carNumber: car.carNumber,
+        modelId: model.id,
+        companyId,
+        year: car.manufacturingYear,
+        mileage: car.mileage,
+        price: car.price,
+        accidentCount: car.accidentCount || 0,
+        explanation: car.explanation || null,
+        accidentDetails: car.accidentDetails || null,
+        status: "possession",
+      });
+    }
+
+    await carRepository.bulkCreateCars(tx, processedCars);
+
+    return {
+      count: processedCars.length,
+    };
+  });
 }
 
 export default {

--- a/src/typings/car.ts
+++ b/src/typings/car.ts
@@ -46,7 +46,7 @@ export interface CarResponse {
 
 export type CarList = {
   currentPage: number;
-  totalPage: number;
+  totalPages: number;
   totalItemCount: number;
   data: CarResponse[];
 };


### PR DESCRIPTION
carController에서 대용량 파일 업로드 부분인 createReadStream ~ .on("end", async ()는 Express 핸들링 체계 밖의 비동기 이벤트 루프이기 때문에, 서비스 안에서 발생한 에러를 asyncHandler로 잡지 못해 부득이하게 저부분만 try catch를 사용해 next(error)로 넘겨주게 되었습니다. 저 부분에 try catch를 제거하면 잘못된 csv파일을 올릴 시 서버가 닫히게 됩니다.
#130 